### PR TITLE
fix(cli): forward keyword-only likelihood parameters

### DIFF
--- a/src/nullpol/cli/input.py
+++ b/src/nullpol/cli/input.py
@@ -125,11 +125,13 @@ class Input(BilbyInput):
         else:
             raise ValueError(f"Unknown Likelihood class {self.likelihood_type}")
 
-        likelihood_kwargs = {
-            key: value
-            for key, value in likelihood_kwargs.items()
-            if key in inspect.getfullargspec(Likelihood.__init__).args
+        likelihood_signature = inspect.signature(Likelihood.__init__)
+        accepted_keyword_names = {
+            name
+            for name, parameter in likelihood_signature.parameters.items()
+            if parameter.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
         }
+        likelihood_kwargs = {key: value for key, value in likelihood_kwargs.items() if key in accepted_keyword_names}
 
         logger.debug(f"Initialise likelihood {Likelihood} with kwargs: \n{likelihood_kwargs}")
         likelihood = Likelihood(**likelihood_kwargs)

--- a/src/nullpol/cli/input.py
+++ b/src/nullpol/cli/input.py
@@ -113,15 +113,16 @@ class Input(BilbyInput):
             "time_frequency_filter": self.meta_data["time_frequency_filter"],  # pylint: disable=no-member
             "priors": self.search_priors,
         }
+        extra_likelihood_kwargs = self.extra_likelihood_kwargs
         if self.likelihood_type == "Chi2TimeFrequencyLikelihood":
             Likelihood = Chi2TimeFrequencyLikelihood
-            likelihood_kwargs.update(self.extra_likelihood_kwargs)
+            likelihood_kwargs.update(extra_likelihood_kwargs)
         elif "." in self.likelihood_type:
             split_path = self.likelihood_type.split(".")
             module = ".".join(split_path[:-1])
             likelihood_class = split_path[-1]
             Likelihood = getattr(import_module(module), likelihood_class)
-            likelihood_kwargs.update(self.extra_likelihood_kwargs)
+            likelihood_kwargs.update(extra_likelihood_kwargs)
         else:
             raise ValueError(f"Unknown Likelihood class {self.likelihood_type}")
 
@@ -131,7 +132,14 @@ class Input(BilbyInput):
             for name, parameter in likelihood_signature.parameters.items()
             if parameter.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
         }
-        likelihood_kwargs = {key: value for key, value in likelihood_kwargs.items() if key in accepted_keyword_names}
+        accepts_extra_kwargs = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in likelihood_signature.parameters.values()
+        )
+        likelihood_kwargs = {
+            key: value
+            for key, value in likelihood_kwargs.items()
+            if key in accepted_keyword_names or (accepts_extra_kwargs and key in extra_likelihood_kwargs)
+        }
 
         logger.debug(f"Initialise likelihood {Likelihood} with kwargs: \n{likelihood_kwargs}")
         likelihood = Likelihood(**likelihood_kwargs)

--- a/tests/cli/test_input.py
+++ b/tests/cli/test_input.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import types
+
 from bilby_pipe.main import parse_args
 
 from nullpol.cli import input as input_module
@@ -32,24 +34,30 @@ class _KeywordOnlyLikelihood:
         self.extra_kwargs = kwargs
 
 
-def test_analysis_config_forwards_keyword_only_parameters(monkeypatch, tmp_path):
-    """A configured analysis forwards its normalized basis to the likelihood."""
-    config_file = tmp_path / "analysis.ini"
-    config_file.write_text(
-        "polarization-modes = pc\n"
-        "polarization-basis = p\n"
-        "extra-likelihood-kwargs = {'regularization_constant': 0.99}\n",
-        encoding="utf-8",
-    )
-    args, unknown_args = parse_args([str(config_file)], create_nullpol_parser(top_level=False))
+class _StrictLikelihood:
+    """Likelihood without ``**kwargs``; unknown extras must be dropped, not forwarded."""
 
-    assert unknown_args == []
-    assert args.polarization_modes == ["pc"]
-    assert args.polarization_basis == ["p"]
+    def __init__(
+        self,
+        interferometers,
+        wavelet_frequency_resolution,
+        wavelet_nx,
+        polarization_modes,
+        polarization_basis=None,
+        time_frequency_filter=None,
+        priors=None,
+    ):
+        self.interferometers = interferometers
+        self.wavelet_frequency_resolution = wavelet_frequency_resolution
+        self.wavelet_nx = wavelet_nx
+        self.polarization_modes = polarization_modes
+        self.polarization_basis = polarization_basis
+        self.time_frequency_filter = time_frequency_filter
+        self.priors = priors
 
-    interferometers = object()
-    time_frequency_filter = object()
-    priors = object()
+
+def _build_inputs(args, *, interferometers, time_frequency_filter, priors, likelihood_type=None):
+    """Assemble a :class:`DataAnalysisInput` wired for :attr:`Input.likelihood`."""
     inputs = object.__new__(DataAnalysisInput)
     inputs._interferometers = interferometers
     inputs.search_priors = priors
@@ -58,8 +66,40 @@ def test_analysis_config_forwards_keyword_only_parameters(monkeypatch, tmp_path)
     inputs.polarization_modes = args.polarization_modes
     inputs.polarization_basis = args.polarization_basis
     inputs.meta_data = {"time_frequency_filter": time_frequency_filter}
-    inputs.likelihood_type = args.likelihood_type
+    inputs.likelihood_type = likelihood_type if likelihood_type is not None else args.likelihood_type
     inputs.extra_likelihood_kwargs = args.extra_likelihood_kwargs
+    return inputs
+
+
+def _parse_config(tmp_path, body):
+    config_file = tmp_path / "analysis.ini"
+    config_file.write_text(body, encoding="utf-8")
+    args, unknown_args = parse_args([str(config_file)], create_nullpol_parser(top_level=False))
+    assert unknown_args == []
+    return args
+
+
+def test_analysis_config_forwards_keyword_only_parameters(monkeypatch, tmp_path):
+    """A configured analysis forwards its normalized basis to the likelihood."""
+    args = _parse_config(
+        tmp_path,
+        "polarization-modes = pc\n"
+        "polarization-basis = p\n"
+        "extra-likelihood-kwargs = {'regularization_constant': 0.99}\n",
+    )
+
+    assert args.polarization_modes == ["pc"]
+    assert args.polarization_basis == ["p"]
+
+    interferometers = object()
+    time_frequency_filter = object()
+    priors = object()
+    inputs = _build_inputs(
+        args,
+        interferometers=interferometers,
+        time_frequency_filter=time_frequency_filter,
+        priors=priors,
+    )
 
     assert inputs.polarization_modes == "pc"
     assert inputs.polarization_basis == "p"
@@ -72,6 +112,68 @@ def test_analysis_config_forwards_keyword_only_parameters(monkeypatch, tmp_path)
     assert likelihood.wavelet_frequency_resolution == 16.0
     assert likelihood.wavelet_nx == 4.0
     assert likelihood.polarization_modes == "pc"
+    assert likelihood.polarization_basis == "p"
+    assert likelihood.time_frequency_filter is time_frequency_filter
+    assert likelihood.extra_kwargs == {"regularization_constant": 0.99}
+
+
+def test_extra_kwargs_dropped_when_likelihood_rejects_variadic(monkeypatch, tmp_path):
+    """A likelihood without ``**kwargs`` must not receive unknown extras (no TypeError)."""
+    args = _parse_config(
+        tmp_path,
+        "polarization-modes = pc\n"
+        "polarization-basis = p\n"
+        "extra-likelihood-kwargs = {'regularization_constant': 0.99}\n",
+    )
+
+    interferometers = object()
+    time_frequency_filter = object()
+    priors = object()
+    inputs = _build_inputs(
+        args,
+        interferometers=interferometers,
+        time_frequency_filter=time_frequency_filter,
+        priors=priors,
+    )
+
+    monkeypatch.setattr(input_module, "Chi2TimeFrequencyLikelihood", _StrictLikelihood)
+
+    # Would raise ``TypeError: unexpected keyword argument 'regularization_constant'``
+    # if the unknown extra were forwarded to a signature without ``**kwargs``.
+    likelihood = input_module.Input.likelihood.fget(inputs)
+
+    assert likelihood.interferometers is interferometers
+    assert likelihood.polarization_basis == "p"
+    assert likelihood.time_frequency_filter is time_frequency_filter
+    assert likelihood.priors is priors
+
+
+def test_dotted_path_forwards_keyword_only_parameters(monkeypatch, tmp_path):
+    """The ``module.Class`` likelihood_type branch also forwards keyword-only params."""
+    args = _parse_config(
+        tmp_path,
+        "polarization-modes = pc\n"
+        "polarization-basis = p\n"
+        "extra-likelihood-kwargs = {'regularization_constant': 0.99}\n",
+    )
+
+    interferometers = object()
+    time_frequency_filter = object()
+    priors = object()
+    inputs = _build_inputs(
+        args,
+        interferometers=interferometers,
+        time_frequency_filter=time_frequency_filter,
+        priors=priors,
+        likelihood_type="my_pkg.CustomLikelihood",
+    )
+
+    fake_module = types.ModuleType("my_pkg")
+    fake_module.CustomLikelihood = _KeywordOnlyLikelihood
+    monkeypatch.setattr(input_module, "import_module", lambda name: fake_module)
+
+    likelihood = input_module.Input.likelihood.fget(inputs)
+
     assert likelihood.polarization_basis == "p"
     assert likelihood.time_frequency_filter is time_frequency_filter
     assert likelihood.extra_kwargs == {"regularization_constant": 0.99}

--- a/tests/cli/test_input.py
+++ b/tests/cli/test_input.py
@@ -36,7 +36,9 @@ def test_analysis_config_forwards_keyword_only_parameters(monkeypatch, tmp_path)
     """A configured analysis forwards its normalized basis to the likelihood."""
     config_file = tmp_path / "analysis.ini"
     config_file.write_text(
-        "polarization-modes = pc\npolarization-basis = p\n",
+        "polarization-modes = pc\n"
+        "polarization-basis = p\n"
+        "extra-likelihood-kwargs = {'regularization_constant': 0.99}\n",
         encoding="utf-8",
     )
     args, unknown_args = parse_args([str(config_file)], create_nullpol_parser(top_level=False))
@@ -72,4 +74,4 @@ def test_analysis_config_forwards_keyword_only_parameters(monkeypatch, tmp_path)
     assert likelihood.polarization_modes == "pc"
     assert likelihood.polarization_basis == "p"
     assert likelihood.time_frequency_filter is time_frequency_filter
-    assert likelihood.extra_kwargs == {}
+    assert likelihood.extra_kwargs == {"regularization_constant": 0.99}

--- a/tests/cli/test_input.py
+++ b/tests/cli/test_input.py
@@ -1,0 +1,75 @@
+"""Tests for likelihood construction from CLI input."""
+
+from __future__ import annotations
+
+from bilby_pipe.main import parse_args
+
+from nullpol.cli import input as input_module
+from nullpol.cli.data_analysis import DataAnalysisInput
+from nullpol.cli.parser import create_nullpol_parser
+
+
+class _KeywordOnlyLikelihood:
+    """Capture the arguments supplied by :attr:`Input.likelihood`."""
+
+    def __init__(
+        self,
+        interferometers,
+        wavelet_frequency_resolution,
+        wavelet_nx,
+        polarization_modes,
+        *args,
+        polarization_basis=None,
+        time_frequency_filter=None,
+        **kwargs,
+    ):
+        self.interferometers = interferometers
+        self.wavelet_frequency_resolution = wavelet_frequency_resolution
+        self.wavelet_nx = wavelet_nx
+        self.polarization_modes = polarization_modes
+        self.polarization_basis = polarization_basis
+        self.time_frequency_filter = time_frequency_filter
+        self.extra_kwargs = kwargs
+
+
+def test_analysis_config_forwards_keyword_only_parameters(monkeypatch, tmp_path):
+    """A configured analysis forwards its normalized basis to the likelihood."""
+    config_file = tmp_path / "analysis.ini"
+    config_file.write_text(
+        "polarization-modes = pc\npolarization-basis = p\n",
+        encoding="utf-8",
+    )
+    args, unknown_args = parse_args([str(config_file)], create_nullpol_parser(top_level=False))
+
+    assert unknown_args == []
+    assert args.polarization_modes == ["pc"]
+    assert args.polarization_basis == ["p"]
+
+    interferometers = object()
+    time_frequency_filter = object()
+    priors = object()
+    inputs = object.__new__(DataAnalysisInput)
+    inputs._interferometers = interferometers
+    inputs.search_priors = priors
+    inputs.wavelet_frequency_resolution = 16.0
+    inputs.wavelet_nx = 4.0
+    inputs.polarization_modes = args.polarization_modes
+    inputs.polarization_basis = args.polarization_basis
+    inputs.meta_data = {"time_frequency_filter": time_frequency_filter}
+    inputs.likelihood_type = args.likelihood_type
+    inputs.extra_likelihood_kwargs = args.extra_likelihood_kwargs
+
+    assert inputs.polarization_modes == "pc"
+    assert inputs.polarization_basis == "p"
+
+    monkeypatch.setattr(input_module, "Chi2TimeFrequencyLikelihood", _KeywordOnlyLikelihood)
+
+    likelihood = input_module.Input.likelihood.fget(inputs)
+
+    assert likelihood.interferometers is interferometers
+    assert likelihood.wavelet_frequency_resolution == 16.0
+    assert likelihood.wavelet_nx == 4.0
+    assert likelihood.polarization_modes == "pc"
+    assert likelihood.polarization_basis == "p"
+    assert likelihood.time_frequency_filter is time_frequency_filter
+    assert likelihood.extra_kwargs == {}


### PR DESCRIPTION
## Summary

- Forward explicit keyword-only parameters when constructing a likelihood from CLI input.
- Add a regression test covering configuration parsing, analysis-input normalization, and likelihood construction.

## Root cause

`Input.likelihood` filtered candidate arguments with `inspect.getfullargspec(...).args`. After `polarization_basis` and `time_frequency_filter` became keyword-only parameters, that filter discarded both values and the likelihood fell back to `None`.

## Validation

- `.venv/bin/pytest` — 304 passed, 104 integration tests deselected.
- `prek run --files src/nullpol/cli/input.py tests/cli/test_input.py` — all configured hooks passed.
- `uv lock --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of likelihood configuration parameters, including reliable forwarding of keyword-only settings like polarization basis and time-frequency filtering.
  * Ensured extra likelihood arguments are applied consistently, while safely dropping unsupported extras when the selected likelihood implementation does not accept them.
  * Added tests covering default likelihood behavior and dotted import likelihood selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->